### PR TITLE
Remove NSLog when missing View menu item

### DIFF
--- a/SCXcodeMinimap/SCXcodeMinimap.m
+++ b/SCXcodeMinimap/SCXcodeMinimap.m
@@ -48,7 +48,6 @@ static SCXcodeMinimap *sharedMinimap = nil;
     NSMenuItem *editMenuItem = [[NSApp mainMenu] itemWithTitle:@"View"];
     
     if(editMenuItem == nil) {
-        NSLog(@"Could not fetch 'View' main menu item");
         return;
     }
     


### PR DESCRIPTION
I like to run specs (`$ xcodebuild $ARGS test`) on the command line, and this little log statement chimes in every time. Can we remove it?
